### PR TITLE
fix: update jackson-databind dependency to version 2.8.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <version.mockito>2.21.0</version.mockito>
     <version.micrometer>1.0.5</version.micrometer>
     <version.gson>2.6.2</version.gson>
-    <version.jackson-databind>2.6.3</version.jackson-databind>
+    <version.jackson-databind>2.8.11.1</version.jackson-databind>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
mitigates com.fasterxml.jackson.core:jackson-databind vulnerability

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).
