### PR TITLE
fix: debian packaging - conform to debian policy

### DIFF
--- a/debian/ari-proxy.service
+++ b/debian/ari-proxy.service
@@ -8,8 +8,8 @@ StartLimitBurst=5
 RestartSec=5
 User=ari-proxy
 Group=ari-proxy
-Environment=HOME=/usr/lib
-WorkingDirectory=/usr/lib
+Environment=HOME=/usr/share/java/ari-proxy
+WorkingDirectory=/usr/share/java/ari-proxy
 LimitNOFILE=512
 ExecStart=/usr/bin/java \
 	-Xmx1024m \
@@ -17,8 +17,8 @@ ExecStart=/usr/bin/java \
 	-Dfile.encoding=UTF-8 \
 	-Dconfig.file=/etc/ari-proxy/service.conf \
 	-Dlog4j.configurationFile=/etc/ari-proxy/log4j2.xml \
-	-javaagent:/usr/lib/ari-proxy/jolokia-jvm-1.6.0-agent.jar \
-	-jar /usr/lib/ari-proxy/ari-proxy.jar
+	-javaagent:/usr/share/java/ari-proxy/jolokia-jvm-1.6.0-agent.jar \
+	-jar /usr/share/java/ari-proxy/ari-proxy.jar
 
 Restart=on-failure
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -8,15 +8,15 @@ case "$1" in
 			--no-create-home \
 			--disabled-password \
 			--disabled-login \
-			--home /usr/lib/ari-proxy \
+			--home /usr/share/java/ari-proxy \
 			--quiet \
 			ari-proxy
 	;;
 esac
 
-chown root:root /usr/lib/ari-proxy/ari-proxy.jar
-chmod 0644 /usr/lib/ari-proxy/ari-proxy.jar
-chmod 0644 /usr/lib/ari-proxy/jolokia-jvm-1.6.0-agent.jar
+chown root:root /usr/share/java/ari-proxy/ari-proxy.jar
+chmod 0644 /usr/share/java/ari-proxy/ari-proxy.jar
+chmod 0644 /usr/share/java/ari-proxy/jolokia-jvm-1.6.0-agent.jar
 
 chown -R ari-proxy:ari-proxy /var/log/ari-proxy
 chmod 0755 /var/log/ari-proxy


### PR DESCRIPTION
use paths as specified in https://wiki.debian.org/DebianJavaPackaging

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).