### PR TITLE
fix: install systemd template unit file without debhelper

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,3 +1,3 @@
-usr/lib/ari-proxy
+usr/share/java/ari-proxy
 var/log/ari-proxy
 etc/ari-proxy

--- a/debian/rules
+++ b/debian/rules
@@ -18,10 +18,10 @@ override_dh_fixperms:
 override_dh_usrlocal:
 override_dh_strip_nondeterminism:
 
-override_dh_install: copy_package copy_jolokia_agent
+override_dh_install: copy_package copy_jolokia_agent setup_systemd_unit_file
 
 %:
-	dh $@ --with-systemd
+	dh $@
 
 ##########
 # Helper #
@@ -38,3 +38,7 @@ copy_package: build_package setup_service_lib_dir
 
 copy_jolokia_agent: setup_service_lib_dir
 	curl http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.0/jolokia-jvm-1.6.0-agent.jar --output $(SERVICE_LIB_DIR)/jolokia-jvm-1.6.0-agent.jar
+
+setup_systemd_unit_file:
+	mkdir -p $(DEB_PREFIX)/lib/systemd/system
+	cp debian/ari-proxy@.service $(DEB_PREFIX)/lib/systemd/system/ari-proxy@.service

--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@ SERVICE_NAME=ari-proxy
 SERVICE_VERSION=0.9.0
 SERVICE_USER=$(SERVICE_NAME)
 SERVICE_GROUP=$(SERVICE_NAME)
-SERVICE_LIB_DIR=$(DEB_PREFIX)/usr/lib/$(SERVICE_NAME)
+SERVICE_LIB_DIR=$(DEB_PREFIX)/usr/share/java/$(SERVICE_NAME)
 
 override_dh_auto_clean:
 override_dh_auto_build:


### PR DESCRIPTION
### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).

### required only for more thorough changes:
- [ ] Made sure there is a corresponding ticket in the project's [issue tracker](https://github.com/retel-io/ari-proxy/issues).
- [ ] Made sure the ticket has been discussed and prioritized by the team.
- [ ] Has appropriate unit tests.
