### PR TITLE
tests: Fix AriCommandsResponseKafkaProcessorTest

### DIFF
--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
@@ -18,7 +18,6 @@ import akka.stream.Materializer;
 import akka.stream.Supervision;
 import akka.stream.Supervision.Directive;
 import akka.stream.javadsl.Keep;
-import akka.stream.javadsl.RestartSource;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,8 +39,6 @@ import io.retel.ariproxy.metrics.StopCallSetupTimer;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import java.nio.charset.Charset;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletionStage;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -80,18 +77,11 @@ public class AriCommandResponseKafkaProcessor {
 			return Supervision.restart();
 		};
 
-		final Source<ConsumerRecord<String, String>, NotUsed> restartSource = RestartSource.withBackoff(
-				Duration.of(1, ChronoUnit.SECONDS),
-				Duration.of(10, ChronoUnit.SECONDS),
-				0.2,
-				() -> source
-		);
-
 		final ActorMaterializer materializer = ActorMaterializer.create(
 				ActorMaterializerSettings.create(system).withSupervisionStrategy(decider),
 				system);
 
-		restartSource
+		source
 				.log(">>>   ARI COMMAND", ConsumerRecord::value).withAttributes(LOG_LEVELS)
 				.map(AriCommandResponseKafkaProcessor::unmarshallAriCommandEnvelope)
 				.map(msgEnvelope -> {
@@ -142,12 +132,19 @@ public class AriCommandResponseKafkaProcessor {
 	private static String lookupCallContext(
 			final String resourceId,
 			final ActorRef callcontextProvider) {
+
+		System.out.println(callcontextProvider);
+
+		final ProvideCallContext message = new ProvideCallContext(resourceId, ProviderPolicy.LOOKUP_ONLY);
+		System.out.println(message);
+
 		return PatternsAdapter.<CallContextProvided>ask(
 				callcontextProvider,
-				new ProvideCallContext(resourceId, ProviderPolicy.LOOKUP_ONLY),
+				message,
 				100
 		)
 				.await()
+				.onSuccess(provided -> System.out.println(provided))
 				.get()
 				.callContext();
 	}


### PR DESCRIPTION
Note: the RestartSource is now being injected in order to control it
during tests.

Co-authored-by: Joeran Vinzens <vinzens@sipgate.de>

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).

