### PR TITLE
chore: Fix broken stasis event json

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -14,7 +14,7 @@ Example of an encapsulated ARI event (see `payload` field) as it is published to
 ```json
 {
    "commandsTopic" : "ari-callcontroller-demo-commands-000000000002",
-   "payload" : stasisApp,
+   "payload" : "{\"type\":\"StasisStart\",\"timestamp\":\"2018-09-27T12:00:28.699+0200\",\"args\":[],\"channel\":{\"id\":\"1538042428.94989\",\"name\":\"PJSIP/proxy-0000ba78\",\"state\":\"Ring\",\"caller\":{\"name\":\"\",\"number\":\"555-12345\"},\"connected\":{\"name\":\"\",\"number\":\"\"},\"accountcode\":\"\",\"dialplan\":{\"context\":\"default\",\"exten\":\"10000\",\"priority\":3},\"creationtime\":\"2018-09-27T12:00:28.698+0200\",\"language\":\"en\",\"channelvars\":{}},\"asterisk_id\":\"00:00:00:00:00:02\",\"application\":\"callcontroller-demo\"}",
    "type" : "STASIS_START",
    "resourceId" : "1538042428.94989"
 }

--- a/src/test/java/io/retel/ariproxy/boundary/events/StasisEvents.java
+++ b/src/test/java/io/retel/ariproxy/boundary/events/StasisEvents.java
@@ -14,14 +14,14 @@ public class StasisEvents {
 					+ "      \"format\" : \"g722\"\n"
 					+ "   },\n"
 					+ "   \"asterisk_id\" : \"00:00:00:00:00:02\",\n"
-					+ "   \"stasisApp\" : \"test-app\",\n"
+					+ "   \"application\" : \"test-app\",\n"
 					+ "   \"type\" : \"RecordingFinished\"\n"
 					+ "}\n";
 
 	public static final String unknownEvent =
 			"{\n"
 					+ "  \"type\" : \"Unknown\",\n"
-					+ "  \"stasisApp\" : \"test-app\",\n"
+					+ "  \"application\" : \"test-app\",\n"
 					+ "  \"playback\" : {\n"
 					+ "     \"id\" : \"072f6484-f781-405b-8c30-0a9a4496d14d\",\n"
 					+ "     \"state\" : \"done\",\n"
@@ -35,14 +35,14 @@ public class StasisEvents {
 	public static final String applicationReplacedEvent =
 			"{\n"
 					+ "   \"asterisk_id\" : \"00:00:00:00:00:01\",\n"
-					+ "   \"stasisApp\" : \"test-app\",\n"
+					+ "   \"application\" : \"test-app\",\n"
 					+ "   \"type\" : \"ApplicationReplaced\"\n"
 					+ "}\n";
 
 	public static final String playbackFinishedEvent =
 			"{\n"
 					+ "  \"type\" : \"PlaybackFinished\",\n"
-					+ "  \"stasisApp\" : \"test-app\",\n"
+					+ "  \"application\" : \"test-app\",\n"
 					+ "  \"playback\" : {\n"
 					+ "     \"id\" : \"072f6484-f781-405b-8c30-0a9a4496d14d\",\n"
 					+ "     \"state\" : \"done\",\n"
@@ -80,6 +80,6 @@ public class StasisEvents {
 					+ "   \"type\" : \"StasisStart\",\n"
 					+ "   \"timestamp\" : \"2018-07-30T17:38:24.436+0200\",\n"
 					+ "   \"args\" : [],\n"
-					+ "   \"stasisApp\" : \"test-app\"\n"
+					+ "   \"application\" : \"test-app\"\n"
 					+ "}";
 }


### PR DESCRIPTION
Some inline json has previously been broken (probably during a refactor-rename). This concerned:

- docs example for StasisStart
- mocks for tests

This PR simply "reverted" the affected lines.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).
