### PR TITLE
refactor: Consolidate json marshallers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,16 +33,10 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>2.21.0</version.mockito>
     <version.micrometer>1.0.5</version.micrometer>
-    <version.gson>2.6.2</version.gson>
     <version.jackson-databind>2.8.11.1</version.jackson-databind>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>${version.gson}</version>
-    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
@@ -21,7 +21,8 @@ import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.retel.ariproxy.akkajavainterop.PatternsAdapter;
 import io.retel.ariproxy.boundary.callcontext.api.CallContextProvided;
 import io.retel.ariproxy.boundary.callcontext.api.ProvideCallContext;
@@ -38,6 +39,7 @@ import io.retel.ariproxy.config.ServiceConfig;
 import io.retel.ariproxy.metrics.StopCallSetupTimer;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import io.vavr.control.Try;
 import java.nio.charset.Charset;
 import java.util.concurrent.CompletionStage;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -50,6 +52,11 @@ public class AriCommandResponseKafkaProcessor {
 			Logging.InfoLevel(),
 			Logging.ErrorLevel()
 	);
+
+	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final ObjectReader reader = mapper.readerFor(AriCommandEnvelope.class);
+	private static final ObjectWriter ariMessageEnvelopeWriter = mapper.writerFor(AriMessageEnvelope.class);
+	private static final ObjectWriter ariResponseWriter = mapper.writerFor(AriResponse.class);
 
 	public static ProcessingPipeline<ConsumerRecord<String, String>, CommandResponseHandler> commandResponseProcessing() {
 		return config -> system -> commandResponseHandler -> callContextProvider -> metricsService -> source -> sink -> () -> run(
@@ -126,17 +133,14 @@ public class AriCommandResponseKafkaProcessor {
 	}
 
 	private static AriCommandEnvelope unmarshallAriCommandEnvelope(final ConsumerRecord<String, String> record) {
-		return new Gson().fromJson(record.value(), AriCommandEnvelope.class);
+		return Try.of(() -> (AriCommandEnvelope) reader.readValue(record.value())).getOrElseThrow(t -> new RuntimeException(t));
 	}
 
 	private static String lookupCallContext(
 			final String resourceId,
 			final ActorRef callcontextProvider) {
 
-		System.out.println(callcontextProvider);
-
 		final ProvideCallContext message = new ProvideCallContext(resourceId, ProviderPolicy.LOOKUP_ONLY);
-		System.out.println(message);
 
 		return PatternsAdapter.<CallContextProvided>ask(
 				callcontextProvider,
@@ -151,7 +155,7 @@ public class AriCommandResponseKafkaProcessor {
 
 	private static Tuple2<AriMessageEnvelope, CallContextAndResourceId> envelopeAriResponse(
 			AriResponse ariResponse, CallContextAndResourceId callContextAndResourceId, String kafkaCommandsTopic) {
-		String payload = io.vavr.control.Try.of(() -> new ObjectMapper().writeValueAsString(ariResponse))
+		final String payload = Try.of(() -> ariResponseWriter.writeValueAsString(ariResponse))
 				.getOrElseThrow(t -> new RuntimeException("Failed to serialize AriResponse", t));
 
 		final AriMessageEnvelope envelope = new AriMessageEnvelope(
@@ -165,7 +169,7 @@ public class AriCommandResponseKafkaProcessor {
 	}
 
 	private static String marshallAriMessageEnvelope(AriMessageEnvelope messageEnvelope) {
-		return io.vavr.control.Try.of(() -> new ObjectMapper().writeValueAsString(messageEnvelope))
+		return Try.of(() -> ariMessageEnvelopeWriter.writeValueAsString(messageEnvelope))
 				.getOrElseThrow(t -> new RuntimeException("Failed to serialize AriResponse", t));
 	}
 

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
@@ -9,6 +9,7 @@ import static io.vavr.API.Some;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
@@ -48,6 +49,8 @@ public enum AriCommandType {
             body -> None()
     );
 
+    private static final ObjectReader reader = new ObjectMapper().reader();
+
     private final Function<String, Boolean> identifierPredicate;
     private final Function<String, Option<Try<String>>> resourceIdUriExtractor;
     private final Function<String, Option<Try<String>>> resourceIdBodyExtractor;
@@ -81,7 +84,7 @@ public enum AriCommandType {
     }
 
     private static Function<String, Option<Try<String>>> resourceIdFromBody(final String resourceIdXPath) {
-        return body -> Some(Try.of(() -> new ObjectMapper().readTree(body))
+        return body -> Some(Try.of(() -> reader.readTree(body))
                 .toOption()
                 .flatMap(root -> Option.of(root.at(resourceIdXPath)))
                 .map(JsonNode::asText)

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriMessageType.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriMessageType.java
@@ -6,6 +6,7 @@ import static io.vavr.API.Some;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 import java.util.function.Function;
@@ -44,6 +45,8 @@ public enum AriMessageType {
 	RESPONSE("AriResponse", body -> None()),
 	UNKNOWN("UnknownAriMessage", body -> Some(Try.failure(new RuntimeException(String.format("Failed to extract resourceId from body=%s", body)))));
 
+	private static final ObjectReader reader = new ObjectMapper().reader();
+
 	private final String typeName;
 	private final Function<String, Option<Try<String>>> resourceIdExtractor;
 
@@ -63,7 +66,7 @@ public enum AriMessageType {
 	}
 
 	private static Function<String, Option<Try<String>>> resourceIdFromBody(final String resourceIdXPath) {
-		return body -> Some(Try.of(() -> new ObjectMapper().readTree(body))
+		return body -> Some(Try.of(() -> reader.readTree(body))
 				.toOption()
 				.flatMap(root -> Option.of(root.at(resourceIdXPath)))
 				.map(JsonNode::asText)


### PR DESCRIPTION
We now use jackson over gson anywhere we need a marshaller.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).
