### PR TITLE
feat: treat all nested json objects as such

### DIFF
--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
@@ -20,6 +20,7 @@ import akka.stream.Supervision.Directive;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -39,6 +40,7 @@ import io.retel.ariproxy.config.ServiceConfig;
 import io.retel.ariproxy.metrics.StopCallSetupTimer;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import io.vavr.control.Option;
 import io.vavr.control.Try;
 import java.nio.charset.Charset;
 import java.util.concurrent.CompletionStage;
@@ -57,6 +59,7 @@ public class AriCommandResponseKafkaProcessor {
 	private static final ObjectReader reader = mapper.readerFor(AriCommandEnvelope.class);
 	private static final ObjectWriter ariMessageEnvelopeWriter = mapper.writerFor(AriMessageEnvelope.class);
 	private static final ObjectWriter ariResponseWriter = mapper.writerFor(AriResponse.class);
+	private static final ObjectWriter genericWriter = mapper.writer();
 
 	public static ProcessingPipeline<ConsumerRecord<String, String>, CommandResponseHandler> commandResponseProcessing() {
 		return config -> system -> commandResponseHandler -> callContextProvider -> metricsService -> source -> sink -> () -> run(
@@ -199,13 +202,20 @@ public class AriCommandResponseKafkaProcessor {
 
 	private static HttpRequest toHttpRequest(AriCommand ariCommand, String uri, String user, String password) {
 		final String method = ariCommand.getMethod();
+		final JsonNode body = ariCommand.getBody();
+
+		final String bodyJson = Option.of(body)
+				.map(value -> Try.of(() -> genericWriter.writeValueAsString(value)))
+				.getOrElse(Try.success(""))
+				.getOrElseThrow(t -> new RuntimeException(t));
+
 		return HttpMethods.lookup(method)
 				.map(validHttpMethod -> HttpRequest
 						.create()
 						.withMethod(validHttpMethod)
 						.addCredentials(HttpCredentials.createBasicHttpCredentials(user, password))
 						.withUri(uri + ariCommand.getUrl())
-						.withEntity(ContentTypes.APPLICATION_JSON, ariCommand.getBody().getBytes())
+						.withEntity(ContentTypes.APPLICATION_JSON, bodyJson.getBytes())
 				)
 				.orElseThrow(() -> new RuntimeException(String.format("Invalid http method: %s", method)));
 	}

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
@@ -58,7 +58,6 @@ public class AriCommandResponseKafkaProcessor {
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final ObjectReader reader = mapper.readerFor(AriCommandEnvelope.class);
 	private static final ObjectWriter ariMessageEnvelopeWriter = mapper.writerFor(AriMessageEnvelope.class);
-	private static final ObjectWriter ariResponseWriter = mapper.writerFor(AriResponse.class);
 	private static final ObjectWriter genericWriter = mapper.writer();
 
 	public static ProcessingPipeline<ConsumerRecord<String, String>, CommandResponseHandler> commandResponseProcessing() {
@@ -158,13 +157,10 @@ public class AriCommandResponseKafkaProcessor {
 
 	private static Tuple2<AriMessageEnvelope, CallContextAndResourceId> envelopeAriResponse(
 			AriResponse ariResponse, CallContextAndResourceId callContextAndResourceId, String kafkaCommandsTopic) {
-		final String payload = Try.of(() -> ariResponseWriter.writeValueAsString(ariResponse))
-				.getOrElseThrow(t -> new RuntimeException("Failed to serialize AriResponse", t));
-
 		final AriMessageEnvelope envelope = new AriMessageEnvelope(
 				AriMessageType.RESPONSE,
 				kafkaCommandsTopic,
-				payload,
+				ariResponse,
 				callContextAndResourceId.getResourceId(),
 				callContextAndResourceId.getCommandId()
 		);

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommand.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommand.java
@@ -3,16 +3,18 @@ package io.retel.ariproxy.boundary.commandsandresponses.auxiliary;
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class AriCommand {
 
 	private String method = null;
 	private String url = null;
-	private String body = null;
+	private JsonNode body = null;
 
 	public AriCommand() {
 	}
 
-	public AriCommand(final String method, final String url, final String body) {
+	public AriCommand(final String method, final String url, final JsonNode body) {
 		this.method = method;
 		this.url = url;
 		this.body = body;
@@ -26,7 +28,7 @@ public class AriCommand {
 		return url;
 	}
 
-	public String getBody() {
+	public JsonNode getBody() {
 		return body;
 	}
 

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriMessageEnvelope.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriMessageEnvelope.java
@@ -7,14 +7,14 @@ public class AriMessageEnvelope {
 
 	private AriMessageType type;
 	private String commandsTopic;
-	private String payload;
+	private Object payload;
 	private String resourceId;
 	private String commandId;
 
 	public AriMessageEnvelope() {
 	}
 
-	public AriMessageEnvelope(AriMessageType type, String commandsTopic, String payload, String resourceId,
+	public AriMessageEnvelope(AriMessageType type, String commandsTopic, Object payload, String resourceId,
 			String commandId) {
 		this.commandsTopic = commandsTopic;
 		this.payload = payload;
@@ -24,7 +24,7 @@ public class AriMessageEnvelope {
 	}
 
 
-	public AriMessageEnvelope(AriMessageType type, String commandsTopic, String payload, String resourceId) {
+	public AriMessageEnvelope(AriMessageType type, String commandsTopic, Object payload, String resourceId) {
 		this(type, commandsTopic, payload, resourceId, null);
 	}
 
@@ -36,7 +36,7 @@ public class AriMessageEnvelope {
 		return commandsTopic;
 	}
 
-	public String getPayload() {
+	public Object getPayload() {
 		return payload;
 	}
 

--- a/src/main/java/io/retel/ariproxy/boundary/events/AriEventProcessing.java
+++ b/src/main/java/io/retel/ariproxy/boundary/events/AriEventProcessing.java
@@ -66,7 +66,8 @@ public class AriEventProcessing {
 			LoggingAdapter log,
 			Runnable applicationReplacedHandler) {
 
-		final String messageBody = message.asTextMessage().getStrictText();
+		final JsonNode messageBody = Try.of(() -> reader.readTree(message.asTextMessage().getStrictText())).getOrElseThrow(t -> new RuntimeException(t));
+
 		final String eventTypeString = getValueFromMessageByPath(message, "/type").getOrElseThrow(t -> t);
 		final AriMessageType ariMessageType = AriMessageType.fromType(eventTypeString);
 
@@ -100,13 +101,14 @@ public class AriEventProcessing {
 			LoggingAdapter log,
 			String resourceId,
 			String callContext,
-			String messageBody) {
+			JsonNode messageBody) {
 
 		final AriMessageEnvelope envelope = new AriMessageEnvelope(
 				type,
 				kafkaCommandsTopic,
 				messageBody,
-				resourceId);
+				resourceId
+		);
 
 		return Try.of(() -> writer.writeValueAsString(envelope))
 				.map(marshalledEnvelope -> {

--- a/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessorTest.java
+++ b/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessorTest.java
@@ -81,7 +81,7 @@ class AriCommandResponseKafkaProcessorTest {
 				+ "   \"ariCommand\" : {\n"
 				+ "      \"url\" : \"/channels/1533286879.42/play/c4958563-1ba4-4f2f-a60f-626a624bf0e6\",\n"
 				+ "      \"method\" : \"POST\",\n"
-				+ "      \"body\" : \"{\\\"media\\\": \\\"sound:hd/register_success\\\", \\\"lang\\\":\\\"de\\\"}\"\n"
+				+ "      \"body\" : {\"media\": \"sound:hd/register_success\", \"lang\":\"de\"}"
 				+ "   }\n"
 				+ "}");
 


### PR DESCRIPTION
### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).

Previously the ari command body as well as the ari message envelope payload (ari response and ari event) have been expected to be or respectively been published as a string with an embedded json object. Treating the entire message as a json object makes the entire marshalling process more convenient.

