### PR TITLE
fix: upgrade jackson-databind to v2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>2.21.0</version.mockito>
     <version.micrometer>1.0.5</version.micrometer>
-    <version.jackson-databind>2.8.11.3</version.jackson-databind>
+    <version.jackson-databind>2.9.9</version.jackson-databind>
     <version.google-guava>26.0-jre</version.google-guava>
     <version.lettuce>5.1.4.RELEASE</version.lettuce>
   </properties>

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
@@ -88,6 +88,7 @@ public enum AriCommandType {
 
     private static Function<String, Option<Try<String>>> resourceIdFromBody(final String resourceIdXPath) {
         return body -> Some(Try.of(() -> reader.readTree(body))
+                .flatMap(root -> Option.of(root).toTry())
                 .toOption()
                 .flatMap(root -> Option.of(root.at(resourceIdXPath)))
                 .map(JsonNode::asText)


### PR DESCRIPTION
deals with CVE-2019-12086

- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).
- [x] Made sure the ticket has been discussed and prioritized by the team.
- [x] Has appropriate unit tests.
