### PR TITLE
set jackson-databind version to 2.9.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>2.21.0</version.mockito>
     <version.micrometer>1.0.5</version.micrometer>
-    <version.jackson-databind>2.9.9</version.jackson-databind>
+    <version.jackson-databind>2.9.9.1</version.jackson-databind>
     <version.google-guava>26.0-jre</version.google-guava>
     <version.lettuce>5.1.4.RELEASE</version.lettuce>
   </properties>


### PR DESCRIPTION
deals with:
- https://www.cvedetails.com/cve/CVE-2019-12814/
- https://www.cvedetails.com/cve/CVE-2019-14439/
- https://www.cvedetails.com/cve/CVE-2019-14379/

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).
