### PR TITLE
Update dependencies

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -1,0 +1,8 @@
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <ignoreVersion type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|EA|ce|CE|ccs|CCS)[-_\.]?[0-9]*</ignoreVersion>
+    </ignoreVersions>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -19,23 +19,23 @@
     <shaded-classifier-name>fat</shaded-classifier-name>
     <version.maven-shade-plugin>1.5</version.maven-shade-plugin>
     <version.maven-surefire-plugin>3.0.0-M1</version.maven-surefire-plugin>
-    <version.scala.compat>2.12</version.scala.compat>
-    <version.akka>2.5.16</version.akka>
-    <version.akka.http>10.1.5</version.akka.http>
-    <version.akka.stream.kafka>0.22</version.akka.stream.kafka>
-    <version.vavr>0.9.2</version.vavr>
-    <version.commons-lang3>3.7</version.commons-lang3>
-    <version.log4j>2.10.0</version.log4j>
+    <version.scala.compat>2.13</version.scala.compat>
+    <version.akka>2.6.8</version.akka>
+    <version.akka.http>10.1.12</version.akka.http>
+    <version.akka.stream.kafka>2.0.4</version.akka.stream.kafka>
+    <version.vavr>0.10.3</version.vavr>
+    <version.commons-lang3>3.11</version.commons-lang3>
+    <version.log4j>2.13.3</version.log4j>
     <version.log4j.staticshutdown>1.1.0</version.log4j.staticshutdown>
-    <version.expiringmap>0.5.8</version.expiringmap>
-    <version.junit>5.2.0</version.junit>
-    <version.junit-platform>1.2.0</version.junit-platform>
-    <version.hamcrest>1.3</version.hamcrest>
-    <version.mockito>2.21.0</version.mockito>
-    <version.micrometer>1.0.5</version.micrometer>
-    <version.jackson-databind>2.10.2</version.jackson-databind>
-    <version.google-guava>26.0-jre</version.google-guava>
-    <version.lettuce>5.1.4.RELEASE</version.lettuce>
+    <version.expiringmap>0.5.9</version.expiringmap>
+    <version.junit>5.6.2</version.junit>
+    <version.junit-platform>1.6.2</version.junit-platform>
+    <version.hamcrest>2.2</version.hamcrest>
+    <version.mockito>3.4.4</version.mockito>
+    <version.micrometer>1.5.3</version.micrometer>
+    <version.jackson-databind>2.11.1</version.jackson-databind>
+    <version.google-guava>29.0-jre</version.google-guava>
+    <version.lettuce>5.3.2.RELEASE</version.lettuce>
   </properties>
 
   <dependencies>
@@ -153,12 +153,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-surefire-provider</artifactId>
-      <version>${version.junit-platform}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>${version.hamcrest}</version>
@@ -209,35 +203,32 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${version.maven-surefire-plugin}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${version.junit-platform}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${version.junit}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${version.maven-surefire-plugin}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${version.junit-platform}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.1</version>
+        <configuration>
+          <rulesUri>file:///${project.basedir}/maven-version-rules.xml</rulesUri>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>display-dependency-updates</goal>
             </goals>
           </execution>
         </executions>

--- a/src/test/java/io/retel/ariproxy/boundary/events/AriEventProcessingTest.java
+++ b/src/test/java/io/retel/ariproxy/boundary/events/AriEventProcessingTest.java
@@ -202,7 +202,9 @@ class AriEventProcessingTest {
 
 	@Test
 	void verifyGetCallContextReturnsAFailedTryIfNoCallContextCanBeProvided() {
-		assertThat(AriEventProcessing.getCallContext("RESOURCE_ID", system.lookupRoot(), ProviderPolicy.CREATE_IF_MISSING).isFailure(), is(true));
+		new TestKit(system) {{
+			assertThat(AriEventProcessing.getCallContext("RESOURCE_ID", getRef(), ProviderPolicy.CREATE_IF_MISSING).isFailure(), is(true));
+		}};
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
Update all ari-proxy maven dependencies to their up-to-date version. Adds [`versions-maven-plugin`](https://www.mojohaus.org/versions-maven-plugin/) as build plugin to make future dependency upgrades easy.

The Test `verifyGetCallContextReturnsAFailedTryIfNoCallContextCanBeProvided` had to be changed to not use the root actor to pass a new validation inside the depended-upon Akka libraries.