### PR TITLE
Enforce Java Google Style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,7 @@ This is the process for committing code to the ari-proxy project. There are of c
 5. The Pull Request will then be reviewed.
 6. After the review, you should resolve issues brought up by the reviewers as needed, iterating until the reviewers give their thumbs up.
 7. Once the code has passed review the Pull Request can be merged.
+
+## Code style
+
+We use [spotless](https://github.com/diffplug/spotless) to gradually enforce [Google Java Style](https://google.github.io/styleguide/javaguide.html). Your build will fail, if changed files do not comply with the formatting guidelines. To automatically format your changed files correctly, run ` mvn spotless:apply`. 

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,27 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.6.0</version>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <ratchetFrom>origin/master</ratchetFrom>
+          <java>
+            <importOrder />
+            <removeUnusedImports />
+            <googleJavaFormat />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>2.1</version>


### PR DESCRIPTION
The formatting in this project is not consistent and currently neither a recommendation nor some kind of enforcement of a particular code style exists.

This PR adds [spotless](https://github.com/diffplug/spotless) maven plugin to gradually enforce [Google Java Style](https://google.github.io/styleguide/javaguide.html). Builds will fail, if _changed_ files do not comply with the formatting guidelines. Changed files can be automatically formatted correctly by running ` mvn spotless:apply`.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).

### required only for more thorough changes:
- [ ] Made sure there is a corresponding ticket in the project's [issue tracker](https://github.com/retel-io/ari-proxy/issues).
- [ ] Made sure the ticket has been discussed and prioritized by the team.
- [ ] Has appropriate unit tests.
