### PR TITLE
fix: extract resource from body

### DIFF
--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
@@ -192,7 +192,7 @@ public class AriCommandResponseKafkaProcessor {
         kafkaCommandsTopic,
         ariResponse,
         context.getCallContext(),
-        command.extractResources().toJavaList(),
+        command.extractResourceRelations().map(AriResourceRelation::getResource).toJavaList(),
         context.getCommandId(),
         new CommandRequest(command.getMethod(), command.getUrl()));
   }

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessor.java
@@ -29,7 +29,6 @@ import io.retel.ariproxy.boundary.processingpipeline.ProcessingPipeline;
 import io.retel.ariproxy.metrics.StopCallSetupTimer;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
-import io.vavr.collection.List;
 import io.vavr.concurrent.Future;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
@@ -186,17 +185,16 @@ public class AriCommandResponseKafkaProcessor {
       AriResponse ariResponse,
       CallContextAndCommandRequestContext context,
       String kafkaCommandsTopic) {
-    final List<AriResource> ariResources =
-        AriCommandType.extractAllResources(context.getAriCommand().getUrl());
+    final AriCommand command = context.getAriCommand();
 
     return new AriMessageEnvelope(
         AriMessageType.RESPONSE,
         kafkaCommandsTopic,
         ariResponse,
         context.getCallContext(),
-        ariResources.toJavaList(),
+        command.extractResources().toJavaList(),
         context.getCommandId(),
-        new CommandRequest(context.getAriCommand().getMethod(), context.getAriCommand().getUrl()));
+        new CommandRequest(command.getMethod(), command.getUrl()));
   }
 
   private static String marshallAriMessageEnvelope(AriMessageEnvelope messageEnvelope) {

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessing.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessing.java
@@ -1,24 +1,31 @@
 package io.retel.ariproxy.boundary.commandsandresponses;
 
+import akka.Done;
 import akka.actor.ActorRef;
 import io.retel.ariproxy.akkajavainterop.PatternsAdapter;
 import io.retel.ariproxy.boundary.callcontext.api.CallContextRegistered;
 import io.retel.ariproxy.boundary.callcontext.api.RegisterCallContext;
 import io.retel.ariproxy.boundary.commandsandresponses.auxiliary.AriCommand;
 import io.retel.ariproxy.boundary.commandsandresponses.auxiliary.AriResource;
+import io.retel.ariproxy.boundary.commandsandresponses.auxiliary.AriResourceRelation;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 
 public class AriCommandResponseProcessing {
 
-  public static Try<Void> registerCallContext(
+  public static Try<Done> registerCallContext(
       final ActorRef callContextProvider, final String callContext, final AriCommand ariCommand) {
 
     if (!ariCommand.extractCommandType().isCreationCommand()) {
-      return Try.success(null);
+      return Try.success(Done.done());
     }
 
-    final Option<AriResource> maybeResource = AriResource.ofAriCommand(ariCommand);
+    final Option<AriResource> maybeResource =
+        ariCommand
+            .extractResourceRelations()
+            .find(AriResourceRelation::isCreated)
+            .map(AriResourceRelation::getResource);
+
     if (maybeResource.isEmpty()) {
       return Try.failure(
           new RuntimeException(
@@ -32,7 +39,7 @@ public class AriCommandResponseProcessing {
           PatternsAdapter.<CallContextRegistered>ask(
                   callContextProvider, new RegisterCallContext(resource.getId(), callContext), 100)
               .await();
-          return null;
+          return Done.done();
         });
   }
 }

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommand.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommand.java
@@ -7,12 +7,16 @@ import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vavr.Value;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 
 public class AriCommand {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   private final String method;
   private final String url;
   private final JsonNode body;
@@ -43,20 +47,38 @@ public class AriCommand {
     return AriCommandType.fromRequestUri(getUrl());
   }
 
-  public List<AriResource> extractResources() {
+  public List<AriResourceRelation> extractResourceRelations() {
     List<AriResource> ariResources = AriCommandType.extractAllResources(getUrl());
 
-    final AriCommandType commandType = extractCommandType();
-    final Option<AriResource> resourceFromBody =
-        commandType
-            .extractResourceIdFromBody(getBody().toString())
-            .flatMap(Value::toOption)
-            .map(resourceId -> new AriResource(commandType.getResourceType(), resourceId));
-    if (resourceFromBody.isDefined() && !ariResources.contains(resourceFromBody.get())) {
-      ariResources = ariResources.push(resourceFromBody.get());
+    final AriCommandType commandType = AriCommandType.fromRequestUri(getUrl());
+    if (!commandType.isCreationCommand()) {
+      return ariResources.map(r -> new AriResourceRelation(r, false));
     }
 
-    return ariResources;
+    final Option<AriResource> createdResourceFromUri =
+        ariResources.find(resource -> resource.getType().equals(commandType.getResourceType()));
+
+    try {
+      final Option<AriResource> createdResourceFromBody =
+          commandType
+              .extractResourceIdFromBody(OBJECT_MAPPER.writeValueAsString(getBody()))
+              .flatMap(Value::toOption)
+              .map(resourceId -> new AriResource(commandType.getResourceType(), resourceId));
+
+      final Option<AriResource> createdResource =
+          createdResourceFromUri.orElse(createdResourceFromBody);
+
+      if (createdResource.isDefined() && !ariResources.contains(createdResource.get())) {
+        ariResources = ariResources.push(createdResource.get());
+      }
+
+      return ariResources.map(
+          ariResource ->
+              new AriResourceRelation(
+                  ariResource, createdResource.map(r -> r.equals(ariResource)).getOrElse(false)));
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Unable to serialize command body: " + this, e);
+    }
   }
 
   @Override

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
@@ -6,7 +6,7 @@ import static io.vavr.API.Some;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import io.vavr.collection.List;
+import io.vavr.collection.*;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 import java.util.HashMap;

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriResourceRelation.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriResourceRelation.java
@@ -5,21 +5,21 @@ import static org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCod
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
-public class AriResource {
-  private final AriResourceType type;
-  private final String id;
+public class AriResourceRelation {
+  private final AriResource resource;
+  private final boolean isCreated;
 
-  public AriResource(final AriResourceType type, final String id) {
-    this.type = type;
-    this.id = id;
+  public AriResourceRelation(final AriResource resource, final boolean isCreated) {
+    this.resource = resource;
+    this.isCreated = isCreated;
   }
 
-  public AriResourceType getType() {
-    return type;
+  public AriResource getResource() {
+    return resource;
   }
 
-  public String getId() {
-    return id;
+  public boolean isCreated() {
+    return isCreated;
   }
 
   @Override

--- a/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessorTest.java
+++ b/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseKafkaProcessorTest.java
@@ -140,6 +140,13 @@ class AriCommandResponseKafkaProcessorTest {
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
           Arguments.of(
+              "messages/commands/bridgeCreateCommandWithBody.json",
+              HttpResponse.create()
+                  .withStatus(StatusCodes.OK)
+                  .withEntity(loadJsonAsString("messages/ari/responses/bridgeCreateResponse.json")),
+              "messages/responses/bridgeCreateResponseWithBody.json",
+              "BRIDGE_ID"),
+          Arguments.of(
               "messages/commands/channelPlaybackCommand.json",
               HttpResponse.create().withStatus(StatusCodes.OK).withEntity("{ \"key\":\"value\" }"),
               "messages/responses/channelPlaybackResponse.json",
@@ -157,9 +164,13 @@ class AriCommandResponseKafkaProcessorTest {
     }
   }
 
-  private static String loadJsonAsString(final String fileName) throws IOException {
+  private static String loadJsonAsString(final String fileName) {
     final ClassLoader classLoader = AriCommandResponseKafkaProcessorTest.class.getClassLoader();
     final File file = new File(classLoader.getResource(fileName).getFile());
-    return new String(Files.readAllBytes(file.toPath()));
+    try {
+      return new String(Files.readAllBytes(file.toPath()));
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to load file " + fileName, e);
+    }
   }
 }

--- a/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessingTest.java
+++ b/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessingTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import akka.Done;
 import akka.actor.ActorSystem;
 import akka.testkit.javadsl.TestKit;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +42,7 @@ class AriCommandResponseProcessingTest {
     final TestKit callContextProvider = new TestKit(system);
     final AriCommand ariCommand = new AriCommand(null, "/channels/CHANNEL_ID/answer", null);
 
-    final Try<Void> res =
+    final Try<Done> res =
         AriCommandResponseProcessing.registerCallContext(
             callContextProvider.getRef(), "CALL_CONTEXT", ariCommand);
 
@@ -55,7 +56,7 @@ class AriCommandResponseProcessingTest {
     final AriCommand ariCommand =
         new AriCommand(null, "/channels/CHANNEL_ID/play/PLAYBACK_ID", null);
 
-    final Try<Void> res =
+    final Try<Done> res =
         AriCommandResponseProcessing.registerCallContext(
             callContextProvider.getRef(), "CALL_CONTEXT", ariCommand);
 
@@ -70,7 +71,7 @@ class AriCommandResponseProcessingTest {
   @Test
   void registerCallContextThrowsARuntimeExceptionIfTheAriCommandIsMalformed() {
     final AriCommand ariCommand = new AriCommand(null, "/channels", null);
-    final Try<Void> res = AriCommandResponseProcessing.registerCallContext(null, null, ariCommand);
+    final Try<Done> res = AriCommandResponseProcessing.registerCallContext(null, null, ariCommand);
 
     assertTrue(res.isFailure());
   }
@@ -82,7 +83,7 @@ class AriCommandResponseProcessingTest {
         "{ \"method\":\"POST\", \"url\":\"/channels/CHANNEL_ID/record\", \"body\":{\"name\":\"RECORD_NAME\"}}";
     final AriCommand ariCommand = ariCommandReader.readValue(json);
 
-    final Try<Void> res =
+    final Try<Done> res =
         AriCommandResponseProcessing.registerCallContext(
             callContextProvider.getRef(), "CALL_CONTEXT", ariCommand);
 
@@ -101,7 +102,7 @@ class AriCommandResponseProcessingTest {
         "{ \"method\":\"POST\", \"url\":\"/channels/create\", \"body\":{\"channelId\":\"channel-Id\"}}";
     final AriCommand ariCommand = ariCommandReader.readValue(json);
 
-    final Try<Void> res =
+    final Try<Done> res =
         AriCommandResponseProcessing.registerCallContext(
             callContextProvider.getRef(), "CALL_CONTEXT", ariCommand);
 

--- a/src/test/resources/messages/ari/responses/bridgeCreateResponse.json
+++ b/src/test/resources/messages/ari/responses/bridgeCreateResponse.json
@@ -1,0 +1,11 @@
+{
+  "id": "BRIDGE_ID",
+  "name": "BRIDGE_NAME",
+  "technology": "simple_bridge",
+  "bridge_type": "mixing",
+  "bridge_class": "stasis",
+  "creator": "Stasis",
+  "channels": [],
+  "creationtime": "2020-12-01T09:59:10.289+0100",
+  "video_mode": "talker"
+}

--- a/src/test/resources/messages/commands/bridgeCreateCommandWithBody.json
+++ b/src/test/resources/messages/commands/bridgeCreateCommandWithBody.json
@@ -1,0 +1,12 @@
+{
+  "callContext": "CALL_CONTEXT",
+  "commandId": "COMMAND_ID",
+  "ariCommand": {
+    "url": "/bridges",
+    "body": {
+      "bridgeId": "BRIDGE_ID",
+      "name": "BRIDGE_NAME"
+    },
+    "method": "POST"
+  }
+}

--- a/src/test/resources/messages/responses/bridgeCreateResponseWithBody.json
+++ b/src/test/resources/messages/responses/bridgeCreateResponseWithBody.json
@@ -1,0 +1,30 @@
+{
+  "type": "RESPONSE",
+  "commandsTopic": "commandsTopic",
+  "payload": {
+    "body": {
+      "id": "BRIDGE_ID",
+      "name": "BRIDGE_NAME",
+      "technology": "simple_bridge",
+      "bridge_type": "mixing",
+      "bridge_class": "stasis",
+      "creator": "Stasis",
+      "channels": [],
+      "creationtime": "2020-12-01T09:59:10.289+0100",
+      "video_mode": "talker"
+    },
+    "status_code": 200
+  },
+  "callContext": "CALL_CONTEXT",
+  "resources": [
+    {
+      "type": "BRIDGE",
+      "id": "BRIDGE_ID"
+    }
+  ],
+  "commandId": "COMMAND_ID",
+  "commandRequest": {
+    "method": "POST",
+    "url": "/bridges"
+  }
+}


### PR DESCRIPTION
The feature of including resourceType and Ids in responses introduced in #48 does not work correctly, when resourceIds are only defined in the command's body.

Example:

```
{
  "callContext": "CALL_CONTEXT",
  "commandId": "COMMAND_ID",
  "ariCommand": {
    "url": "/bridges",
    "body": {
      "bridgeId": "BRIDGE_ID",
      "name": "BRIDGE_NAME"
    },
    "method": "POST"
  }
}
```

In the current implementation, the newly created bridge `BRIDGE_ID` is not included in the responses `resources`. This is fixed through the PR.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).