### PR TITLE
fix: remove empty string body from command handling test case

### DIFF
--- a/src/test/resources/messages/commands/channelAnswerCommandWithoutCommandId.json
+++ b/src/test/resources/messages/commands/channelAnswerCommandWithoutCommandId.json
@@ -2,7 +2,6 @@
   "callContext": "CALL_CONTEXT",
   "ariCommand": {
     "url": "/channels/1533218784.36/answer",
-    "body": "",
     "method": "POST"
   }
 }


### PR DESCRIPTION
This test case is confusing: if the command does not need a body, you should not call it with `""` but without any body field.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).