### PR TITLE
feat: use user-agent header 'ari-proxy'

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,6 +15,7 @@ akka {
   }
   http {
     client {
+      user-agent-header = ari-proxy
       idle-timeout = 60s # the default
 
       websocket {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -8,6 +8,7 @@ akka {
 
   http {
     client {
+      user-agent-header = ari-proxy
       idle-timeout = 60s # the default
 
       websocket {


### PR DESCRIPTION
Use `ari-proxy` as default value for the `User-Agent` header of the HTTP client (instead of current [default value](https://github.com/akka/akka-http/blob/c0fa9d2/akka-http-core/src/main/resources/reference.conf#L327-L331) `akka-http/${akka.http.version}`).

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).
