### PR TITLE
feat: introduces connection check for kafka and configured topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <version.jackson>2.12.4</version.jackson>
     <version.google-guava>30.1.1-jre</version.google-guava>
     <version.lettuce>6.1.4.RELEASE</version.lettuce>
+    <version.kafka-test-junit5>3.2.2</version.kafka-test-junit5>
+    <version.kafka-test-server>2.7.0</version.kafka-test-server>
   </properties>
 
   <dependencies>
@@ -182,6 +184,18 @@
       <groupId>org.cassandraunit</groupId>
       <artifactId>cassandra-unit</artifactId>
       <version>${version.cassandraunit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.salesforce.kafka.test</groupId>
+      <artifactId>kafka-junit5</artifactId>
+      <version>${version.kafka-test-junit5}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_${version.scala.compat}</artifactId>
+      <version>${version.kafka-test-server}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/io/retel/ariproxy/Main.java
+++ b/src/main/java/io/retel/ariproxy/Main.java
@@ -55,16 +55,14 @@ public class Main {
 
     system.registerOnTermination(() -> System.exit(0));
 
-    final ActorRef actorRef =
-        system.actorOf(
-            HealthService.props(serviceConfig.getInt(HTTPPORT)), HealthService.ACTOR_NAME);
+    system.actorOf(HealthService.props(serviceConfig.getInt(HTTPPORT)), HealthService.ACTOR_NAME);
+
+    system.actorOf(
+        KafkaConnectionCheck.props(serviceConfig.getConfig(KAFKA)),
+        KafkaConnectionCheck.ACTOR_NAME);
 
     final ActorRef metricsService =
         system.actorOf(MetricsService.props(), MetricsService.ACTOR_NAME);
-    final ActorRef kafkaConnectionCheck =
-        system.actorOf(
-            KafkaConnectionCheck.props(serviceConfig.getConfig(KAFKA)),
-            KafkaConnectionCheck.ACTOR_NAME);
     final ActorRef callContextProvider =
         system.actorOf(CallContextProvider.props(metricsService), CallContextProvider.ACTOR_NAME);
 

--- a/src/main/java/io/retel/ariproxy/Main.java
+++ b/src/main/java/io/retel/ariproxy/Main.java
@@ -20,6 +20,7 @@ import io.retel.ariproxy.boundary.commandsandresponses.AriCommandResponseKafkaPr
 import io.retel.ariproxy.boundary.events.WebsocketMessageToProducerRecordTranslator;
 import io.retel.ariproxy.boundary.processingpipeline.Run;
 import io.retel.ariproxy.health.HealthService;
+import io.retel.ariproxy.health.KafkaConnectionCheck;
 import io.retel.ariproxy.metrics.MetricsService;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -54,10 +55,16 @@ public class Main {
 
     system.registerOnTermination(() -> System.exit(0));
 
-    system.actorOf(HealthService.props(serviceConfig.getInt(HTTPPORT)), HealthService.ACTOR_NAME);
+    final ActorRef actorRef =
+        system.actorOf(
+            HealthService.props(serviceConfig.getInt(HTTPPORT)), HealthService.ACTOR_NAME);
 
     final ActorRef metricsService =
         system.actorOf(MetricsService.props(), MetricsService.ACTOR_NAME);
+    final ActorRef kafkaConnectionCheck =
+        system.actorOf(
+            KafkaConnectionCheck.props(serviceConfig.getConfig(KAFKA)),
+            KafkaConnectionCheck.ACTOR_NAME);
     final ActorRef callContextProvider =
         system.actorOf(CallContextProvider.props(metricsService), CallContextProvider.ACTOR_NAME);
 

--- a/src/main/java/io/retel/ariproxy/boundary/callcontext/CallContextProvider.java
+++ b/src/main/java/io/retel/ariproxy/boundary/callcontext/CallContextProvider.java
@@ -10,6 +10,7 @@ import io.retel.ariproxy.boundary.callcontext.api.CallContextRegistered;
 import io.retel.ariproxy.boundary.callcontext.api.ProvideCallContext;
 import io.retel.ariproxy.boundary.callcontext.api.ProviderPolicy;
 import io.retel.ariproxy.boundary.callcontext.api.RegisterCallContext;
+import io.retel.ariproxy.health.api.NewHealthRecipient;
 import io.retel.ariproxy.health.api.ProvideHealthReport;
 import io.retel.ariproxy.health.api.ProvideMonitoring;
 import io.retel.ariproxy.persistence.PersistentCache;
@@ -35,8 +36,12 @@ public class CallContextProvider extends PersistentCache {
 
   @Override
   public void preStart() throws Exception {
-    getContext().getSystem().eventStream().publish(new ProvideMonitoring(ACTOR_NAME, self()));
+    registerMonitoring();
     super.preStart();
+  }
+
+  private void registerMonitoring() {
+    getContext().getSystem().eventStream().publish(new ProvideMonitoring(ACTOR_NAME, self()));
   }
 
   public Receive createReceive() {
@@ -44,6 +49,7 @@ public class CallContextProvider extends PersistentCache {
         .match(RegisterCallContext.class, this::registerCallContextHandler)
         .match(ProvideCallContext.class, this::provideCallContextHandler)
         .match(ProvideHealthReport.class, this::provideHealthReportHandler)
+        .match(NewHealthRecipient.class, ignored -> this.registerMonitoring())
         .build();
   }
 

--- a/src/main/java/io/retel/ariproxy/health/KafkaConnectionCheck.java
+++ b/src/main/java/io/retel/ariproxy/health/KafkaConnectionCheck.java
@@ -1,0 +1,114 @@
+package io.retel.ariproxy.health;
+
+import akka.actor.AbstractLoggingActor;
+import akka.actor.Props;
+import akka.japi.pf.ReceiveBuilder;
+import com.typesafe.config.Config;
+import io.retel.ariproxy.akkajavainterop.PatternsAdapter;
+import io.retel.ariproxy.health.api.HealthReport;
+import io.retel.ariproxy.health.api.NewHealthRecipient;
+import io.retel.ariproxy.health.api.ProvideHealthReport;
+import io.retel.ariproxy.health.api.ProvideMonitoring;
+import io.vavr.concurrent.Future;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+public class KafkaConnectionCheck extends AbstractLoggingActor {
+
+  public static final String ACTOR_NAME = "kafka-connection-check";
+
+  static final String EVENTS_AND_RESPONSES_TOPIC = "events-and-responses-topic";
+  static final String COMMANDS_TOPIC = "commands-topic";
+  static final String BOOTSTRAP_SERVERS = "bootstrap-servers";
+  static final String CONSUMER_GROUP = "consumer-group";
+
+  private final Config kafkaConfig;
+  private final List<String> wantedTopics;
+
+  public static Props props(Config kafkaConfig) {
+    return Props.create(KafkaConnectionCheck.class, kafkaConfig);
+  }
+
+  private KafkaConnectionCheck(Config kafkaConfig) {
+    this.kafkaConfig = kafkaConfig;
+    this.wantedTopics =
+        Arrays.asList(
+            kafkaConfig.getString(COMMANDS_TOPIC),
+            kafkaConfig.getString(EVENTS_AND_RESPONSES_TOPIC));
+  }
+
+  @Override
+  public Receive createReceive() {
+    return ReceiveBuilder.create()
+        .match(ProvideHealthReport.class, this::provideHealthReportHandler)
+        .match(NewHealthRecipient.class, ignored -> this.registerMonitoring())
+        .matchAny(msg -> log().warning("Unexpected message received {}", msg))
+        .build();
+  }
+
+  private void registerMonitoring() {
+    getContext().getSystem().eventStream().publish(new ProvideMonitoring(ACTOR_NAME, self()));
+  }
+
+  @Override
+  public void preStart() throws Exception {
+    context().system().eventStream().subscribe(self(), NewHealthRecipient.class);
+    registerMonitoring();
+    super.preStart();
+  }
+
+  private void provideHealthReportHandler(ProvideHealthReport cmd) {
+    final String bootstrapServers = kafkaConfig.getString(BOOTSTRAP_SERVERS);
+    final String consumerGroup = kafkaConfig.getString(CONSUMER_GROUP) + "-check";
+
+    PatternsAdapter.pipeTo(
+        provideHealthReport(bootstrapServers, consumerGroup, wantedTopics),
+        sender(),
+        context().dispatcher());
+  }
+
+  private Future<HealthReport> provideHealthReport(
+      final String bootstrapServers, final String consumerGroup, final List<String> neededTopics) {
+    final Properties kafkaProperties = new Properties();
+    kafkaProperties.setProperty(
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
+    kafkaProperties.setProperty(
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        StringDeserializer.class.getCanonicalName());
+    kafkaProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
+    kafkaProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+    return Future.of(
+        () -> {
+          try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(kafkaProperties)) {
+
+            final Map<String, List<PartitionInfo>> receivedTopics =
+                consumer.listTopics(Duration.ofMillis(100));
+
+            final List<String> missingTopics =
+                neededTopics.stream()
+                    .filter(s -> !receivedTopics.containsKey(s))
+                    .collect(Collectors.toList());
+            if (!missingTopics.isEmpty()) {
+              return HealthReport.error(
+                  String.format(
+                      "KafkaConnectionCheck: missing topics, please create: %s", missingTopics));
+            }
+
+            return HealthReport.ok();
+
+          } catch (TimeoutException timeoutException) {
+            return HealthReport.error(
+                String.format(
+                    "KafkaConnectionCheck: timeout during connection to servers: %s",
+                    bootstrapServers));
+          }
+        });
+  }
+}

--- a/src/main/java/io/retel/ariproxy/health/api/HealthResponse.java
+++ b/src/main/java/io/retel/ariproxy/health/api/HealthResponse.java
@@ -1,33 +1,36 @@
 package io.retel.ariproxy.health.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class HealthResponse {
 
-	private final List<String> errors;
-	private final boolean isOk;
+  private final List<String> errors;
+  private final boolean isOk;
 
-	private HealthResponse(boolean isOk, List<String> errors) {
-		this.isOk = isOk;
-		this.errors = errors;
-	}
+  private HealthResponse(boolean isOk, List<String> errors) {
+    this.isOk = isOk;
+    this.errors = errors;
+  }
 
-	public List<String> errors() {
-		return errors;
-	}
+  @JsonProperty
+  public boolean isOk() {
+    return isOk;
+  }
 
-	public boolean isOk() {
-		return isOk;
-	}
+  @JsonProperty
+  public List<String> errors() {
+    return errors;
+  }
 
-	public static HealthResponse fromErrors(List<String> errors) {
-		return new HealthResponse(errors.size() == 0, errors);
-	}
+  public static HealthResponse fromErrors(List<String> errors) {
+    return new HealthResponse(errors.size() == 0, errors);
+  }
 
-	@Override
-	public String toString() {
-		return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
-	}
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+  }
 }

--- a/src/main/java/io/retel/ariproxy/health/api/NewHealthRecipient.java
+++ b/src/main/java/io/retel/ariproxy/health/api/NewHealthRecipient.java
@@ -1,0 +1,7 @@
+package io.retel.ariproxy.health.api;
+
+public class NewHealthRecipient {
+  public static NewHealthRecipient getInstance() {
+    return new NewHealthRecipient();
+  }
+}

--- a/src/test/java/io/retel/ariproxy/health/KafkaConnectionCheckTest.java
+++ b/src/test/java/io/retel/ariproxy/health/KafkaConnectionCheckTest.java
@@ -1,0 +1,106 @@
+package io.retel.ariproxy.health;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.testkit.javadsl.TestKit;
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+import com.typesafe.config.impl.ConfigImpl;
+import io.retel.ariproxy.health.api.HealthReport;
+import io.retel.ariproxy.health.api.ProvideHealthReport;
+import io.retel.ariproxy.persistence.*;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class KafkaConnectionCheckTest {
+
+  @RegisterExtension
+  public static final SharedKafkaTestResource sharedKafkaTestResource =
+      new SharedKafkaTestResource();
+
+  public static final String COMMANDS_TOPIC = "commands-topic";
+  public static final String EVENTS_AND_RESPONSES_TOPIC = "events-and-responses-topic";
+
+  private final String TEST_SYSTEM = this.getClass().getSimpleName();
+  private ActorSystem system;
+
+  @AfterEach
+  void teardown() {
+    TestKit.shutdownActorSystem(system);
+    system.terminate();
+  }
+
+  @BeforeEach
+  void setup() {
+    system = ActorSystem.create(TEST_SYSTEM);
+    sharedKafkaTestResource.getKafkaTestUtils().createTopic(COMMANDS_TOPIC, 1, (short) 1);
+    sharedKafkaTestResource
+        .getKafkaTestUtils()
+        .createTopic(EVENTS_AND_RESPONSES_TOPIC, 1, (short) 1);
+  }
+
+  @Test
+  void provideOkHealthReport() {
+
+    final Config testConfig =
+        ConfigImpl.emptyConfig("KafkaConnectionCheckTest")
+            .withValue(
+                KafkaConnectionCheck.BOOTSTRAP_SERVERS,
+                ConfigValueFactory.fromAnyRef(sharedKafkaTestResource.getKafkaConnectString()))
+            .withValue(
+                KafkaConnectionCheck.CONSUMER_GROUP,
+                ConfigValueFactory.fromAnyRef("my-test-consumer-group"))
+            .withValue(
+                KafkaConnectionCheck.COMMANDS_TOPIC, ConfigValueFactory.fromAnyRef(COMMANDS_TOPIC))
+            .withValue(
+                KafkaConnectionCheck.EVENTS_AND_RESPONSES_TOPIC,
+                ConfigValueFactory.fromAnyRef(EVENTS_AND_RESPONSES_TOPIC));
+
+    final TestKit probe = new TestKit(system);
+    final ActorRef connectionCheck =
+        system.actorOf(Props.create(KafkaConnectionCheck.class, testConfig));
+
+    probe.send(connectionCheck, ProvideHealthReport.getInstance());
+
+    final HealthReport report = probe.expectMsgClass(Duration.ofMillis(200), HealthReport.class);
+
+    assertThat(report.errors().size(), is(0));
+  }
+
+  @Test
+  void provideNotOkHealthReport() {
+
+    final Config testConfig =
+        ConfigImpl.emptyConfig("KafkaConnectionCheckTest")
+            .withValue(
+                KafkaConnectionCheck.BOOTSTRAP_SERVERS,
+                ConfigValueFactory.fromAnyRef(sharedKafkaTestResource.getKafkaConnectString()))
+            .withValue(
+                KafkaConnectionCheck.CONSUMER_GROUP,
+                ConfigValueFactory.fromAnyRef("my-test-consumer-group"))
+            .withValue(
+                KafkaConnectionCheck.COMMANDS_TOPIC,
+                ConfigValueFactory.fromAnyRef("some-non-existing-topic"))
+            .withValue(
+                KafkaConnectionCheck.EVENTS_AND_RESPONSES_TOPIC,
+                ConfigValueFactory.fromAnyRef(EVENTS_AND_RESPONSES_TOPIC));
+
+    final TestKit probe = new TestKit(system);
+    final ActorRef connectionCheck =
+        system.actorOf(Props.create(KafkaConnectionCheck.class, testConfig));
+
+    probe.send(connectionCheck, ProvideHealthReport.getInstance());
+
+    final HealthReport report = probe.expectMsgClass(Duration.ofMillis(200), HealthReport.class);
+
+    assertThat(report.errors().size(), is(1));
+  }
+}


### PR DESCRIPTION
This adds an additional HealthProvider to check whether the kafka brokers are reachable and the expected topics are created.

Improves HTTP response body for /health to provide useful error descriptions.
HealthService publishes Message, when he is ready to receive new MonitoringProviders to avoid missing their registration.

Co-authored-by: mia-krause <mia.elisabeth.krause+github@gmail.com>

### required for all prs:
- [X] Signed the [retel.io CLA](https://github.com/retel-io/cla).

### required only for more thorough changes:
- [X] Has appropriate unit tests.
