### PR TITLE
Fix/cache lookup

### DIFF
--- a/src/main/java/io/retel/ariproxy/boundary/callcontext/CallContextProvider.java
+++ b/src/main/java/io/retel/ariproxy/boundary/callcontext/CallContextProvider.java
@@ -83,13 +83,13 @@ public class CallContextProvider {
             if (error instanceof CallContextLookupError) {
               response = StatusReply.error(error);
             } else {
-              response = StatusReply.error("Unable to lookup call context: " + error.getMessage());
+              response = StatusReply.error(String.format("Unable to lookup call context for resource %s: %s", msg.resourceId(), error.getMessage()));
             }
           } else {
             if (cContext.isPresent()) {
               response = StatusReply.success(new CallContextProvided(cContext.get()));
             } else {
-              response = StatusReply.error("Unable to lookup call context");
+              response = StatusReply.error(String.format("Unable to lookup call context for resource %s", msg.resourceId()));
             }
           }
 

--- a/src/main/java/io/retel/ariproxy/boundary/callcontext/CallContextProvider.java
+++ b/src/main/java/io/retel/ariproxy/boundary/callcontext/CallContextProvider.java
@@ -83,13 +83,20 @@ public class CallContextProvider {
             if (error instanceof CallContextLookupError) {
               response = StatusReply.error(error);
             } else {
-              response = StatusReply.error(String.format("Unable to lookup call context for resource %s: %s", msg.resourceId(), error.getMessage()));
+              response =
+                  StatusReply.error(
+                      String.format(
+                          "Unable to lookup call context for resource %s: %s",
+                          msg.resourceId(), error.getMessage()));
             }
           } else {
             if (cContext.isPresent()) {
               response = StatusReply.success(new CallContextProvided(cContext.get()));
             } else {
-              response = StatusReply.error(String.format("Unable to lookup call context for resource %s", msg.resourceId()));
+              response =
+                  StatusReply.error(
+                      String.format(
+                          "Unable to lookup call context for resource %s", msg.resourceId()));
             }
           }
 

--- a/src/main/java/io/retel/ariproxy/boundary/events/AriEventProcessing.java
+++ b/src/main/java/io/retel/ariproxy/boundary/events/AriEventProcessing.java
@@ -92,9 +92,10 @@ public class AriEventProcessing {
             resourceIdTry ->
                 resourceIdTry.flatMap(
                     resourceId -> {
-                      final ProviderPolicy providerPolicy = AriMessageType.STASIS_START.equals(ariMessageType)
-                          ? ProviderPolicy.CREATE_IF_MISSING
-                          : ProviderPolicy.LOOKUP_ONLY;
+                      final ProviderPolicy providerPolicy =
+                          AriMessageType.STASIS_START.equals(ariMessageType)
+                              ? ProviderPolicy.CREATE_IF_MISSING
+                              : ProviderPolicy.LOOKUP_ONLY;
                       final Try<String> maybeCallContext =
                           getCallContext(
                               resourceId,

--- a/src/main/java/io/retel/ariproxy/boundary/events/AriEventProcessing.java
+++ b/src/main/java/io/retel/ariproxy/boundary/events/AriEventProcessing.java
@@ -92,14 +92,15 @@ public class AriEventProcessing {
             resourceIdTry ->
                 resourceIdTry.flatMap(
                     resourceId -> {
+                      final ProviderPolicy providerPolicy = AriMessageType.STASIS_START.equals(ariMessageType)
+                          ? ProviderPolicy.CREATE_IF_MISSING
+                          : ProviderPolicy.LOOKUP_ONLY;
                       final Try<String> maybeCallContext =
                           getCallContext(
                               resourceId,
                               callContextProvider,
                               maybeCallContextFromChannelVars,
-                              AriMessageType.STASIS_START.equals(ariMessageType)
-                                  ? ProviderPolicy.CREATE_IF_MISSING
-                                  : ProviderPolicy.LOOKUP_ONLY,
+                              providerPolicy,
                               system);
                       return maybeCallContext.flatMap(
                           callContext ->


### PR DESCRIPTION
CallContext cache lookup for new resources is currently broken. This PR fixes the current handling.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).