### PR TITLE
test: disable CassandraPersistenceStoreTest

### DIFF
--- a/src/test/java/io/retel/ariproxy/persistence/plugin/CassandraPersistenceStoreTest.java
+++ b/src/test/java/io/retel/ariproxy/persistence/plugin/CassandraPersistenceStoreTest.java
@@ -12,8 +12,10 @@ import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled
 class CassandraPersistenceStoreTest {
 
   private static final String THE_KEY = "key";


### PR DESCRIPTION
- cassandraunit is not compatible with any java version > 8
- causes freezes on CI servers

Co-authored-by: Julius Flohr <flohr@sipgate.de>
Co-authored-by: Sven Andris <andris@sipgate.de>

### required for all prs:
- [x ] Signed the [retel.io CLA](https://github.com/retel-io/cla).