### PR TITLE
feat: make kafka consumer auto.offset.reset configurable through service.conf

### DIFF
--- a/src/main/java/io/retel/ariproxy/Main.java
+++ b/src/main/java/io/retel/ariproxy/Main.java
@@ -123,7 +123,7 @@ public class Main {
             .withBootstrapServers(kafkaConfig.getString(BOOTSTRAP_SERVERS))
             .withGroupId(kafkaConfig.getString(CONSUMER_GROUP))
             .withProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
-            .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+            .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, kafkaConfig.getString("auto-offset-reset"));
 
     final ProducerSettings<String, String> producerSettings =
         ProducerSettings.create(system, new StringSerializer(), new StringSerializer())

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -35,4 +35,8 @@ service {
     password = ${service.asterisk.password}
     uri = "http://"${service.asterisk.server}"/ari"
   }
+
+  kafka {
+    auto-offset-reset = "earliest"
+  }
 }


### PR DESCRIPTION
It might make sense to be able to easily change the kafka consumer [`auto.offset.reset`](https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset) value when operating ari-proxy, so we make it optionally configurable.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).