### PR TITLE
feat: drain kafka consumer

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,10 +26,12 @@ akka {
   }
 
   kafka.consumer {
+    stop-timeout = 0 # consumer is drained explicitly
     kafka-clients {
       heartbeat.interval.ms = 3000
       session.timeout.ms = 10000
     }
+    connection-checker.enable = true
   }
 
 }

--- a/src/test/java/io/retel/ariproxy/ArchitectureTest.java
+++ b/src/test/java/io/retel/ariproxy/ArchitectureTest.java
@@ -3,6 +3,7 @@ package io.retel.ariproxy;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.*;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import akka.actor.CoordinatedShutdown;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -19,5 +20,7 @@ public class ArchitectureTest {
       classes()
           .should()
           .onlyDependOnClassesThat(
-              resideOutsideOfPackage("akka.actor..").or(resideInAPackage("akka.actor.typed..")));
+              resideOutsideOfPackage("akka.actor..")
+                  .or(resideInAPackage("akka.actor.typed.."))
+                  .or(type(CoordinatedShutdown.class)));
 }

--- a/src/test/java/io/retel/ariproxy/TestArchitectureTest.java
+++ b/src/test/java/io/retel/ariproxy/TestArchitectureTest.java
@@ -17,9 +17,12 @@ public class TestArchitectureTest {
   @ArchTest
   public static final ArchRule NOTHING_DEPENDS_ON_AKKA_CLASSIC =
       classes()
+          .that()
+          .haveSimpleNameNotEndingWith("ArchitectureTest")
           .should()
           .onlyDependOnClassesThat(
               resideOutsideOfPackage("akka.actor..")
                   .or(resideInAPackage("akka.actor.typed.."))
-                  .or(resideInAPackage("akka.actor.testkit.typed..")));
+                  .or(resideInAPackage("akka.actor.testkit.typed.."))
+                  .or(type(ArchitectureTest.class)));
 }


### PR DESCRIPTION
Currently when the service is shutting down, we wait for the passing of [`akka.kafka.consumer.stop-timeout`](https://github.com/akka/alpakka-kafka/blob/v3.0.0/core/src/main/resources/reference.conf#L71-L74), hope there are no more in-flight requests and stop the AriCommandResponseKafkaProcessor stream anyway. With this pull request we now stop the consumer, wait until the stream is actually empty and only then shut it down. This is more safe and usually much faster.

There is a bit of complexity in the implementation because the Kafka consumer source is wrapped in a RestartSource which masks the materialized value and [needs some more involved manual wiring](https://doc.akka.io/docs/alpakka-kafka/3.0.0/errorhandling.html#restarting-the-stream-with-a-backoff-stage) to make it work as expected. To actually take advantage of the restart behavior [`akka.kafka.consumer.connection-checker.enable`](https://github.com/akka/alpakka-kafka/blob/v3.0.0/core/src/main/resources/reference.conf#L132) is set to `true` by default.

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).