### PR TITLE
config: introduce kafka producer config

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -25,13 +25,22 @@ akka {
     }
   }
 
-  kafka.consumer {
-    stop-timeout = 0 # consumer is drained explicitly
-    kafka-clients {
-      heartbeat.interval.ms = 3000
-      session.timeout.ms = 10000
+  kafka {
+    producer {
+      kafka-clients {
+          max.in.flight.requests.per.connection = 1 # This should be set to ensure message order even in case of retries
+          request.timeout.ms = 4000
+          delivery.timeout.ms = 10000
+      }
     }
-    connection-checker.enable = true
+    consumer {
+    stop-timeout = 0 # consumer is drained explicitly
+      kafka-clients {
+        heartbeat.interval.ms = 3000
+        session.timeout.ms = 10000
+      }
+      connection-checker.enable = true
+    }
   }
 
 }


### PR DESCRIPTION
introduces new default config parameter to ensure correct order of messages even in case of retries
also: set default configs for producer timeouts

### required for all prs:
- [x ] Signed the [retel.io CLA](https://github.com/retel-io/cla).

### required only for more thorough changes:
- [x ] Made sure there is a corresponding ticket in the project's [issue tracker](https://github.com/retel-io/ari-proxy/issues).
- [x ] Made sure the ticket has been discussed and prioritized by the team.
- [x ] Has appropriate unit tests.
