### PR TITLE
chore: Keep kafka consumer for health instaed of creating a new one e…

### DIFF
--- a/src/main/java/io/retel/ariproxy/health/KafkaConnectionCheck.java
+++ b/src/main/java/io/retel/ariproxy/health/KafkaConnectionCheck.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -28,85 +28,81 @@ public class KafkaConnectionCheck {
   static final String BOOTSTRAP_SERVERS = "bootstrap-servers";
   static final String CONSUMER_GROUP = "consumer-group";
 
+  private static KafkaConsumer<String, String> consumer;
+
   private KafkaConnectionCheck() {
     throw new IllegalStateException("Utility class");
   }
 
   public static Behavior<ReportKafkaConnectionHealth> create(final Config kafkaConfig) {
+    consumer = createKafkaConsumer(kafkaConfig);
+
     final List<String> wantedTopics =
-        Arrays.asList(
-            kafkaConfig.getString(COMMANDS_TOPIC),
-            kafkaConfig.getString(EVENTS_AND_RESPONSES_TOPIC));
+            Arrays.asList(
+                    kafkaConfig.getString(COMMANDS_TOPIC),
+                    kafkaConfig.getString(EVENTS_AND_RESPONSES_TOPIC));
 
     return Behaviors.receive(ReportKafkaConnectionHealth.class)
-        .onMessage(
-            ReportKafkaConnectionHealth.class,
-            message -> reportHealth(kafkaConfig, wantedTopics, message))
-        .build();
+            .onMessage(
+                    ReportKafkaConnectionHealth.class,
+                    message -> reportHealth(kafkaConfig, wantedTopics, message))
+            .build();
+  }
+
+  private static KafkaConsumer<String, String> createKafkaConsumer(final Config kafkaConfig) {
+    final Properties kafkaProperties = new Properties();
+    kafkaProperties.setProperty(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
+    kafkaProperties.setProperty(
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class.getCanonicalName());
+    kafkaProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, kafkaConfig.getString(CONSUMER_GROUP));
+    kafkaProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfig.getString(BOOTSTRAP_SERVERS));
+    return new KafkaConsumer<>(kafkaProperties);
   }
 
   private static Behavior<ReportKafkaConnectionHealth> reportHealth(
-      final Config kafkaConfig,
-      final List<String> wantedTopics,
-      final ReportKafkaConnectionHealth message) {
+          final Config kafkaConfig,
+          final List<String> wantedTopics,
+          final ReportKafkaConnectionHealth message) {
     provideHealthReport(
             kafkaConfig.getString(BOOTSTRAP_SERVERS),
-            kafkaConfig.getString(CONSUMER_GROUP),
             wantedTopics)
-        .thenAccept(healthReport -> message.replyTo().tell(healthReport));
+            .thenAccept(healthReport -> message.replyTo().tell(healthReport));
 
     return Behaviors.same();
   }
 
   private static CompletableFuture<HealthReport> provideHealthReport(
-      final String bootstrapServers, final String consumerGroup, final List<String> neededTopics) {
-    final Properties kafkaProperties = new Properties();
-    kafkaProperties.setProperty(
-        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
-    kafkaProperties.setProperty(
-        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-        StringDeserializer.class.getCanonicalName());
-    kafkaProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
-    kafkaProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+          final String bootstrapServers, final List<String> neededTopics) {
 
     return CompletableFuture.supplyAsync(
-        () -> {
-          try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(kafkaProperties)) {
+            () -> {
+              try {
+                final Map<String, List<PartitionInfo>> receivedTopics =
+                        consumer.listTopics(Duration.ofMillis(100));
 
-            final Map<String, List<PartitionInfo>> receivedTopics =
-                consumer.listTopics(Duration.ofMillis(100));
+                final List<String> missingTopics =
+                        neededTopics.stream()
+                                .filter(s -> !receivedTopics.containsKey(s)).toList();
+                if (!missingTopics.isEmpty()) {
+                  return HealthReport.error(
+                          String.format(
+                                  "KafkaConnectionCheck: missing topics, please create: %s", missingTopics));
+                }
 
-            final List<String> missingTopics =
-                neededTopics.stream()
-                    .filter(s -> !receivedTopics.containsKey(s))
-                    .collect(Collectors.toList());
-            if (!missingTopics.isEmpty()) {
-              return HealthReport.error(
-                  String.format(
-                      "KafkaConnectionCheck: missing topics, please create: %s", missingTopics));
-            }
+                return HealthReport.ok();
 
-            return HealthReport.ok();
-
-          } catch (TimeoutException timeoutException) {
-            return HealthReport.error(
-                String.format(
-                    "KafkaConnectionCheck: timeout during connection to servers: %s",
-                    bootstrapServers));
-          }
-        });
+              } catch (TimeoutException timeoutException) {
+                return HealthReport.error(
+                        String.format(
+                                "KafkaConnectionCheck: timeout during connection to servers: %s",
+                                bootstrapServers));
+              }
+            });
   }
 
-  public static class ReportKafkaConnectionHealth {
-    final ActorRef<HealthReport> replyTo;
-
-    public ReportKafkaConnectionHealth(final ActorRef<HealthReport> replyTo) {
-      this.replyTo = replyTo;
-    }
-
-    public ActorRef<HealthReport> replyTo() {
-      return replyTo;
-    }
+  public record ReportKafkaConnectionHealth(ActorRef<HealthReport> replyTo) {
 
     @Override
     public String toString() {


### PR DESCRIPTION
…ach time and causing a print of ConsumerConfig

### required for all prs:
- [x] Signed the [retel.io CLA](https://github.com/retel-io/cla).

### required only for more thorough changes:
- [ ] Made sure there is a corresponding ticket in the project's [issue tracker](https://github.com/retel-io/ari-proxy/issues).
- [ ] Made sure the ticket has been discussed and prioritized by the team.
- [ ] Has appropriate unit tests.
