### PR TITLE
feat: only register mapping of resource id to CallContext for POST re…

### DIFF
--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessing.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessing.java
@@ -17,8 +17,7 @@ public class AriCommandResponseProcessing {
       final String callContext,
       final AriCommand ariCommand) {
 
-    if (!(ariCommand.extractCommandType().isCreationCommand()
-        && "POST".equals(ariCommand.getMethod()))) {
+    if (!ariCommand.isCreationCommand()) {
       return Try.success(Done.done());
     }
 

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessing.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessing.java
@@ -17,7 +17,8 @@ public class AriCommandResponseProcessing {
       final String callContext,
       final AriCommand ariCommand) {
 
-    if (!ariCommand.extractCommandType().isCreationCommand()) {
+    if (!(ariCommand.extractCommandType().isCreationCommand()
+        && "POST".equals(ariCommand.getMethod()))) {
       return Try.success(Done.done());
     }
 

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommand.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommand.java
@@ -55,7 +55,7 @@ public class AriCommand {
 
     final AriCommandType commandType = AriCommandType.fromRequestUri(uri);
 
-    if (!commandType.isCreationCommand()) {
+    if (!commandType.isRouteForResourceCreation()) {
       return ariResources.map(r -> new AriResourceRelation(r, false));
     }
 
@@ -83,6 +83,10 @@ public class AriCommand {
     } catch (JsonProcessingException e) {
       throw new IllegalStateException("Unable to serialize command body: " + this, e);
     }
+  }
+
+  public boolean isCreationCommand() {
+    return extractCommandType().isRouteForResourceCreation() && "POST".equals(method);
   }
 
   @Override

--- a/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
+++ b/src/main/java/io/retel/ariproxy/boundary/commandsandresponses/auxiliary/AriCommandType.java
@@ -82,15 +82,15 @@ public enum AriCommandType {
   private static final ObjectReader READER = new ObjectMapper().reader();
 
   private final AriResourceType resourceType;
-  private final boolean isCreationCommand;
+  private final boolean isRouteForResourceCreation;
   private final Function<String, Option<Try<String>>> resourceIdBodyExtractor;
 
   AriCommandType(
       final AriResourceType resourceType,
-      final boolean isCreationCommand,
+      final boolean isRouteForResourceCreation,
       final Function<String, Option<Try<String>>> resourceIdBodyExtractor) {
     this.resourceType = resourceType;
-    this.isCreationCommand = isCreationCommand;
+    this.isRouteForResourceCreation = isRouteForResourceCreation;
     this.resourceIdBodyExtractor = resourceIdBodyExtractor;
   }
 
@@ -121,8 +121,8 @@ public enum AriCommandType {
     return resourceType;
   }
 
-  public boolean isCreationCommand() {
-    return isCreationCommand;
+  public boolean isRouteForResourceCreation() {
+    return isRouteForResourceCreation;
   }
 
   public Option<String> extractResourceIdFromUri(final String uri) {

--- a/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessingTest.java
+++ b/src/test/java/io/retel/ariproxy/boundary/commandsandresponses/AriCommandResponseProcessingTest.java
@@ -54,7 +54,7 @@ class AriCommandResponseProcessingTest {
         AriCommandResponseProcessing.registerCallContext(
             callContextProvider.ref(),
             CALL_CONTEXT,
-            new AriCommand(null, "/channels/CHANNEL_ID/play/PLAYBACK_ID", null));
+            new AriCommand("POST", "/channels/CHANNEL_ID/play/PLAYBACK_ID", null));
 
     assertTrue(result.isSuccess());
     final RegisterCallContext registerCallContext =
@@ -64,13 +64,28 @@ class AriCommandResponseProcessingTest {
   }
 
   @Test
+  void doesNotTryToRegisterACallContextForDeleteRequests() {
+    final TestableCallContextProvider callContextProvider =
+        new TestableCallContextProvider(testKit);
+
+    final Try<Done> result =
+        AriCommandResponseProcessing.registerCallContext(
+            callContextProvider.ref(),
+            CALL_CONTEXT,
+            new AriCommand("DELETE", "/channels/CHANNEL_ID", null));
+
+    assertTrue(result.isSuccess());
+    callContextProvider.probe().expectNoMessage();
+  }
+
+  @Test
   void registerCallContextThrowsARuntimeExceptionIfTheAriCommandIsMalformed() {
     final TestProbe<CallContextProviderMessage> callContextProviderProbe =
         testKit.createTestProbe(CallContextProviderMessage.class);
 
     final Try<Done> result =
         AriCommandResponseProcessing.registerCallContext(
-            callContextProviderProbe.ref(), null, new AriCommand(null, "/channels", null));
+            callContextProviderProbe.ref(), null, new AriCommand("POST", "/channels", null));
 
     assertTrue(result.isFailure());
   }


### PR DESCRIPTION
This pr changes that the mapping of resource identifier to CallContext is only saved for resource creating `POST` requests.

### required for all prs:
- [X] Signed the [retel.io CLA](https://github.com/retel-io/cla).
- [X] Made sure the ticket has been discussed and prioritized by the team.
- [X] Has appropriate unit tests.